### PR TITLE
Change Payloads, Samba, and FTP Paths

### DIFF
--- a/PPPwn/install.sh
+++ b/PPPwn/install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 
-if [ ! -d /boot/firmware/PPPwn/payloads ]; then
-  sudo mkdir /boot/firmware/PPPwn/payloads
+if [ ! -d /PPPwn/payloads ]; then
+  sudo mkdir -p /PPPwn/payloads
 fi
 if [ -z $1 ] ;then
 sudo apt install pppoe dnsmasq iptables nginx php-fpm nmap at -y
@@ -124,7 +124,7 @@ local_umask=077
 allow_writeable_chroot=YES
 chroot_local_user=YES
 user_sub_token=$USER
-local_root=/boot/firmware/PPPwn" | sudo tee /etc/vsftpd.conf
+local_root=/PPPwn" | sudo tee /etc/vsftpd.conf
 sudo sed -i 's^root^^g' /etc/ftpusers
 echo -e '\n\n\033[33mTo use FTP you must set the \033[36mroot\033[33m account password so you can login to the ftp server with full write permissions\033[0m\n'
 while true; do
@@ -216,7 +216,7 @@ echo '[global]
    guest ok = no
 ;   write list = root, @lpadmin
 [pppwn]
-path = /boot/firmware/PPPwn/
+path = /PPPwn/
 writeable=Yes
 create mask=0777
 read only = no

--- a/PPPwn/payloads.php
+++ b/PPPwn/payloads.php
@@ -181,7 +181,7 @@ foreach ($rdir as $x) {
 }
 
 
-$cmd = 'sudo ls /boot/firmware/PPPwn/payloads';
+$cmd = 'sudo ls /PPPwn/payloads';
 exec($cmd ." 2>&1", $sdir, $ret);
 if ($ret == 0 && count($sdir) > 0)
 {
@@ -189,7 +189,7 @@ if ($ret == 0 && count($sdir) > 0)
 		if (str_ends_with($a, ".bin") || str_ends_with($a, ".elf"))
 		{
 			$haspl=1;
-			print("<button name=\"payload\" value=".urlencode('/boot/firmware/PPPwn/payloads/'.$a).">".$a."</button>&nbsp; ");
+			print("<button name=\"payload\" value=".urlencode('/PPPwn/payloads/'.$a).">".$a."</button>&nbsp; ");
 			$cnt++;
 			if ($cnt >= 4)
 			{


### PR DESCRIPTION
Since /boot/firmware is only a few hundred MB, use / instead, since it is usually the remaining size of the boot device.